### PR TITLE
Updated amqp dependency to allow for newer versions, resolving deprecation issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "matthew.woolf@mailonline.co.uk",
   "license": "ISC",
   "dependencies": {
-    "amqp": "^0.2.0",
+    "amqp": ">=0.2.0",
     "winston": "^0.8.3"
   },
   "devDependencies": {},


### PR DESCRIPTION
Updated amqp dependency to allow for newer versions, resolving deprecation issues. Amqp needs to issue a release including already made dependency changes and the lodash dependency deprecation warning will disappear.
